### PR TITLE
plist fix for macOS Tahoe

### DIFF
--- a/CPM for OS X/CPM for OS X-Info.plist
+++ b/CPM for OS X/CPM for OS X-Info.plist
@@ -21,28 +21,13 @@
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
 			<key>LSHandlerRank</key>
-			<string>Alternate</string>
+			<string>Default</string>
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>com.digitalresearch.cpm-executable</string>
-			</array>
-			<key>NSDocumentClass</key>
-			<string>CPMDocument</string>
-		</dict>
-		<dict>
-			<key>CFBundleTypeExtensions</key>
-			<array>
-				<string>com</string>
-			</array>
-			<key>CFBundleTypeName</key>
-			<string>DOS/Windows Executable</string>
-			<key>CFBundleTypeRole</key>
-			<string>Viewer</string>
-			<key>LSHandlerRank</key>
-			<string>Alternate</string>
-			<key>LSItemContentTypes</key>
-			<array>
-				<string>com.microsoft.msdos-executable</string>
+				<string>public.data</string>
+				<string>public.content</string>
+				<string>public.item</string>
 			</array>
 			<key>NSDocumentClass</key>
 			<string>CPMDocument</string>
@@ -101,24 +86,6 @@
 				<key>public.mime-type</key>
 				<array>
 					<string>application/octet-stream</string>
-				</array>
-			</dict>
-		</dict>
-		<dict>
-			<key>UTTypeConformsTo</key>
-			<array>
-				<string>public.data</string>
-				<string>public.executable</string>
-			</array>
-			<key>UTTypeDescription</key>
-			<string>Microsoft MS-DOS application</string>
-			<key>UTTypeIdentifier</key>
-			<string>com.microsoft.msdos-executable</string>
-			<key>UTTypeTagSpecification</key>
-			<dict>
-				<key>public.filename-extension</key>
-				<array>
-					<string>com</string>
 				</array>
 			</dict>
 		</dict>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 CP/M for OS X
 =============
+Build command for macOS this will give you CPM for OS X.app the local directory, move it into the applications directory.
+- CPM for OS X-Info.plist modified so it will run on macOS Tahoe
 
+% xcodebuild -project "CPM for OS X.xcodeproj" \
+           -scheme "CPM for OS X" \
+           -configuration Release \
+           CONFIGURATION_BUILD_DIR="$(pwd)" \
+           clean build
+           
 It…
 
 * allows you to run CP/M-80 software on your Mac:


### PR DESCRIPTION
CPM for OS X-Info.plist

Gets rid of the file check that was producing this error.

Won't open .com files

The document "WS.COM" could
not be opened. CPM for OS X
cannot open file in the
"RetroArch Content File" format.